### PR TITLE
Exercise 3 improvements

### DIFF
--- a/exercises/variables/public/tests.js
+++ b/exercises/variables/public/tests.js
@@ -11,7 +11,8 @@ test('Primary button', function(assert) {
   }, 'styles are incorrect');
   
   assert.hasStyle('.btn.btn-primary', {
-    'background-color': 'rgb(204, 102, 153)',
+    'background-color': '#cc6699',
+    'border-color': '#998099',
     'color': 'rgb(255, 255, 255)',
     'opacity': '1'
   }, 'colors for enabled state are incorrect');
@@ -31,6 +32,7 @@ test('Secondary button', function(assert) {
   
   assert.hasStyle('.btn.btn-secondary', {
     'background-color': '#d2e1dd',
+    'border-color': '#669999',
     'color': 'rgb(0, 0, 0)',
     'opacity': '1'
   }, 'colors for enabled state are incorrect');

--- a/exercises/variables/src/sass/_variables.scss
+++ b/exercises/variables/src/sass/_variables.scss
@@ -1,5 +1,5 @@
-$hopbush: #c69 !default;
-$patina: #699 !default;
+$hopbush: #cc6699 !default;
+$patina: #669999 !default;
 $venus: #998099 !default;
 $nebula: #d2e1dd !default;
 


### PR DESCRIPTION
The task for exercise 3 was clear in the notes, but I noticed a couple things:

- The test for btn-primary’s background color has an rgb value and _variables.scss has a hex value. 
- There weren’t tests for the border colors.

When making these changes the tests they complained about the expected hex values set for $hopbush and $patina.

Thanks for a great workshop! Looking forward to the SEO one tomorrow! 