### PR TITLE
pin node to a compatible node-sass version

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Particularly if you’ve never tried it before, you should install [Microsoft Vi
 ```
 git clone git@github.com:mike-works/sass-fundamentals.git
 cd sass-fundamentals
+nvm install 14.17.6
+nvm use 14.17.6
 npm install
 ```
 


### PR DESCRIPTION
Some instructions on which version(s) of node to use with node-sass would be helpful.

see: https://github.com/mike-works/sass-fundamentals/issues/138#issuecomment-931966862